### PR TITLE
OSP-165: add force sync command for topo_sync

### DIFF
--- a/build_scripts/build-rhel-packages-inner.sh
+++ b/build_scripts/build-rhel-packages-inner.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -eux
+SPEC="/rpmbuild/SPECS/python-bsn-neutronclient.spec"
+
+# RPM runs as root and doesn't like source files owned by a random UID
+OUTER_UID=$(stat -c '%u' $SPEC)
+OUTER_GID=$(stat -c '%g' $SPEC)
+trap "chown -R $OUTER_UID:$OUTER_GID /rpmbuild" EXIT
+chown -R root:root /rpmbuild
+
+ln -s /rpmbuild /root/rpmbuild
+rpmbuild -ba $SPEC
+
+chown -R $OUTER_UID:$OUTER_GID /rpmbuild

--- a/build_scripts/build-rhel-packages.sh
+++ b/build_scripts/build-rhel-packages.sh
@@ -1,20 +1,28 @@
 #!/bin/bash -eux
 
-cd /python-bsn-neutronclient
-python setup.py bdist_rpm \
---release=1 \
---distribution-name=el7.centos \
---requires=python-neutronclient
-
-# copy RPM and tar pkgs to hierarchical format in pkg directory
+DOCKER_IMAGE=$DOCKER_REGISTRY'/horizon-bsn-builder:latest'
 BUILD_OS=centos7-x86_64
 CURR_VERSION=$(awk '/^version/{print $3}' setup.cfg)
+
+docker pull $DOCKER_IMAGE
+
+BUILDDIR=$(mktemp -d)
+mkdir -p $BUILDDIR/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+
+cp dist/* $BUILDDIR/SOURCES/
+cp rhel/* $BUILDDIR/SPECS/
+cp build_scripts/build-rhel-packages-inner.sh $BUILDDIR/build-rhel-packages-inner.sh
+
+docker run -v $BUILDDIR:/rpmbuild $DOCKER_IMAGE /rpmbuild/build-rhel-packages-inner.sh
 
 # Copy built RPMs to pkg/
 OUTDIR=$(readlink -m "pkg/$BUILD_OS/$GIT_BRANCH/$CURR_VERSION")
 rm -rf "$OUTDIR" && mkdir -p "$OUTDIR"
-cp dist/*.rpm "$OUTDIR"
+mv $BUILDDIR/SRPMS/*.rpm "$OUTDIR"
+mv $BUILDDIR/RPMS/noarch/*.rpm "$OUTDIR"
 cp dist/*.tar.gz "$OUTDIR"
 git log > "$OUTDIR/gitlog.txt"
 touch "$OUTDIR/build-$CURR_VERSION"
 ln -snf $(basename $OUTDIR) $OUTDIR/../latest
+
+rm -rf "$BUILDDIR"

--- a/build_scripts/openstack_python_bsn_neutronclient.build
+++ b/build_scripts/openstack_python_bsn_neutronclient.build
@@ -9,10 +9,14 @@ DOCKER_IMAGE=$DOCKER_REGISTRY'/bosi-builder:latest'
 
 echo "Tagging and uploading to PYPI"
 docker pull $DOCKER_IMAGE
-docker run -e GIT_BRANCH=$GIT_BRANCH -v $GIT_REPO:/python-bsn-neutronclient -v $PYPIRC_FILE:/root/.pypirc -v $GNUPG_DIR/.gnupg:/root/.gnupg $DOCKER_IMAGE /python-bsn-neutronclient/build_scripts/upload_to_pypi.sh
+docker run -e GIT_BRANCH=$GIT_BRANCH \
+    -v $GIT_REPO:/python-bsn-neutronclient \
+    -v $PYPIRC_FILE:/root/.pypirc \
+    -v $GNUPG_DIR/.gnupg:/root/.gnupg \
+    $DOCKER_IMAGE /python-bsn-neutronclient/build_scripts/upload_to_pypi.sh
 
 # remove pypi and gpg creds
 sudo rm -rf $GNUPG_DIR
 
 echo "Building RPM packages"
-docker run -e GIT_BRANCH=$GIT_BRANCH -v $GIT_REPO:/python-bsn-neutronclient $DOCKER_IMAGE /python-bsn-neutronclient/build_scripts/build-rhel-packages.sh
+./build_scripts/build-rhel-packages.sh

--- a/python_bsn_neutronclient/v2_0/bsn_plugin_client.py
+++ b/python_bsn_neutronclient/v2_0/bsn_plugin_client.py
@@ -494,3 +494,32 @@ class TenantPoliciesShow(extension.ClientExtensionShow, TenantPolicy):
     """Show a tenant policy."""
 
     shell_command = 'tenant-policies-show'
+
+
+# Force Sync Topology
+class ForceSyncTopology(extension.NeutronClientExtension):
+    resource = 'forcesynctopology'
+    resource_plural = 'forcesynctopologies'
+    object_path = '/%s' % resource_plural
+    resource_path = '/%s/%%s' % resource_plural
+    versions = ['2.0']
+
+
+class ForceSyncTopologiesUpdate(extension.ClientExtensionUpdate,
+                                ForceSyncTopology):
+    """Force a complete Topology Sync to BCF controller."""
+
+    shell_command = 'force-bcf-sync'
+    list_columns = ['id', 'status']
+
+    def args2body(self, parsed_args):
+        body = {'timestamp_ms': 'now'}
+        return {'forcesynctopology': body}
+
+
+class ForceSyncTopologiesList(extension.ClientExtensionList,
+                              ForceSyncTopology):
+    """Show the status of last scheduled Topology Sync to BCF."""
+
+    shell_command = 'bcf-sync-status'
+    list_columns = ['id', 'timestamp_ms', 'timestamp_datetime', 'status']

--- a/rhel/python-bsn-neutronclient.spec
+++ b/rhel/python-bsn-neutronclient.spec
@@ -1,0 +1,50 @@
+%global pypi_name python-bsn-neutronclient
+%global pypi_name_underscore python_bsn_neutronclient
+%global rpm_prefix openstackclient-bigswitch
+
+Name:           %{pypi_name}
+Version:        0.0.4
+Release:        1%{?dist}
+Epoch:          1
+Summary:        Python bindings for Big Switch Networks Neutron API
+License:        ASL 2.0
+URL:            https://pypi.python.org/pypi/%{pypi_name}
+Source0:        https://pypi.python.org/packages/source/b/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python-pbr
+BuildRequires:  python-setuptools
+
+Requires:       python-pbr >= 0.10.8
+Requires:       python-neutronclient >= 6.3.0
+
+%description
+This package contains Big Switch Networks
+python client for Openstack CLI.
+
+%prep
+%setup -q -n %{pypi_name}-%{version}
+
+%build
+export PBR_VERSION=%{version}
+export SKIP_PIP_INSTALL=1
+%{__python2} setup.py build
+
+%install
+%{__python2} setup.py install --skip-build --root %{buildroot}
+
+%files
+%license LICENSE
+%{python2_sitelib}/%{pypi_name_underscore}
+%{python2_sitelib}/*.egg-info
+
+
+%post
+
+%preun
+
+%postun
+
+%changelog
+* Tue Aug 21 2018 Aditya Vaja <wolverine.av@gmail.com> - 0.0.4
+- OSP-165: add force sync command for topo_sync and build changes

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = python-bsn-neutronclient
-version = 0.0.3
+version = 0.0.4
 summary = Python bindings for Big Switch Networks Neutron API
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: @sarath-kumar @WeifanFu-bsn 

 - neutronclient for our commands is a separate package from Queens onwards
 - adding the force sync command that was recently added to the python bsnclient in networking-bigswitch
 - like os-vif-bigswitch, the bsnclient will also be removed from networking-bigswitch
 - otherwise there will be conflicts of path when installing both plugin and neutronclient CLI package