### PR TITLE
OSP-241: fix entry point extension name

### DIFF
--- a/python_bsn_neutronclient/v2_0/bsn_plugin_client.py
+++ b/python_bsn_neutronclient/v2_0/bsn_plugin_client.py
@@ -13,7 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from django.utils.translation import ugettext_lazy as _
+from neutronclient._i18n import _
 from neutronclient.common import extension
 
 

--- a/rhel/python-bsn-neutronclient.spec
+++ b/rhel/python-bsn-neutronclient.spec
@@ -3,7 +3,7 @@
 %global rpm_prefix openstackclient-bigswitch
 
 Name:           %{pypi_name}
-Version:        0.0.4
+Version:        0.0.5
 Release:        1%{?dist}
 Epoch:          1
 Summary:        Python bindings for Big Switch Networks Neutron API
@@ -46,5 +46,7 @@ export SKIP_PIP_INSTALL=1
 %postun
 
 %changelog
+* Mon Oct 08 2018 Aditya Vaja <wolverine.av@gmail.com> - 0.0.5
+- OSP-241: fix entry point extension name and import error
 * Tue Aug 21 2018 Aditya Vaja <wolverine.av@gmail.com> - 0.0.4
 - OSP-165: add force sync command for topo_sync and build changes

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ packages =
 
 [entry_points]
 neutronclient.extension =
-    bsn_extensions = python_bsnclient.v2_0.bsn_plugin_client
+    bsn_extensions = python_bsn_neutronclient.v2_0.bsn_plugin_client
 
 [build_sphinx]
 all-files = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = python-bsn-neutronclient
-version = 0.0.4
+version = 0.0.5
 summary = Python bindings for Big Switch Networks Neutron API
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: @sarath-kumar @WeifanFu-bsn 

 - minor naming and import errors
 - this caused an error when running neutron CLI commands
 - doesn't break functionality for other commands, but causes confusion
 - it also disables our plugin specific CLI commands
 - this patch fixes entry point and another import error for
   translating text