### PR TITLE
OSP-246: Add src_tenant_id and src_segment_id to reachability test for neutron client

### DIFF
--- a/python_bsn_neutronclient/v2_0/bsn_plugin_client.py
+++ b/python_bsn_neutronclient/v2_0/bsn_plugin_client.py
@@ -12,7 +12,6 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-
 from neutronclient._i18n import _
 from neutronclient.common import extension
 
@@ -185,8 +184,14 @@ def _reachabilitytest_updatable_args(parser):
         'name',
         help=_('Name of this reachability test.'))
     parser.add_argument(
+        'src_tenant_id', metavar='src-tenant-id',
+        help=_('Tenant ID of the src-ip.'))
+    parser.add_argument(
         'src_tenant_name', metavar='src-tenant-name',
         help=_('Tenant name of the src-ip.'))
+    parser.add_argument(
+        'src_segment_id', metavar='src-segment-id',
+        help=_('Network id of the src-ip.'))
     parser.add_argument(
         'src_segment_name', metavar='src-segment-name',
         help=_('Network name of the src-ip.'))
@@ -210,8 +215,12 @@ def _reachabilitytest_updatable_args2body(parsed_args, body, client):
     if parsed_args.name:
         body['name'] = parsed_args.name
     if parsed_args.src_tenant_id:
+        body['src_tenant_id'] = parsed_args.src_tenant_id
+    if parsed_args.src_tenant_name:
         body['src_tenant_name'] = parsed_args.src_tenant_name
     if parsed_args.src_segment_id:
+        body['src_segment_id'] = parsed_args.src_segment_id
+    if parsed_args.src_segment_name:
         body['src_segment_name'] = parsed_args.src_segment_name
     if parsed_args.src_ip:
         body['src_ip'] = parsed_args.src_ip
@@ -233,7 +242,8 @@ class ReachabilityTestsList(extension.ClientExtensionList, ReachabilityTest):
     """List Reachability Tests."""
 
     shell_command = 'reachability-tests-list'
-    list_columns = ['id', 'name', 'src_tenant_id', 'src_segment_id',
+    list_columns = ['id', 'name', 'src_tenant_id', 'src_tenant_name',
+                    'src_segment_id', 'src_segment_name',
                     'src_ip', 'dst_ip', 'expected_result']
 
 
@@ -242,7 +252,8 @@ class ReachabilityTestsCreate(extension.ClientExtensionCreate,
     """Create a Reachability Test."""
 
     shell_command = 'reachability-tests-create'
-    list_columns = ['id', 'name', 'src_tenant_id', 'src_segment_id',
+    list_columns = ['id', 'name', 'src_tenant_id', 'src_tenant_name',
+                    'src_segment_id', 'src_segment_name',
                     'src_ip', 'dst_ip', 'expected_result']
 
     def add_known_arguments(self, parser):
@@ -260,7 +271,8 @@ class ReachabilityTestsUpdate(extension.ClientExtensionUpdate,
     """Update a Reachability Test."""
 
     shell_command = 'reachability-tests-update'
-    list_columns = ['id', 'name', 'src_tenant_name', 'src_segment_name',
+    list_columns = ['id', 'name', 'src_tenant_id', 'src_tenant_name',
+                    'src_segment_id', 'src_segment_name',
                     'src_ip', 'dst_ip', 'expected_result']
 
     def add_known_arguments(self, parser):
@@ -278,7 +290,8 @@ class ReachabilityTestsRun(extension.ClientExtensionUpdate,
     """Run a Reachability Test."""
 
     shell_command = 'reachability-tests-run'
-    list_columns = ['id', 'name', 'src_tenant_name', 'src_segment_name',
+    list_columns = ['id', 'name', 'src_tenant_id', 'src_tenant_name',
+                    'src_segment_id', 'src_segment_name',
                     'src_ip', 'dst_ip', 'expected_result', 'test_result',
                     'detail', 'logical_path', 'test_time']
 
@@ -315,7 +328,8 @@ class ReachabilityQuickTestsList(extension.ClientExtensionList,
     """List Reachability Quick Tests."""
 
     shell_command = 'reachability-quick-tests-list'
-    list_columns = ['id', 'name', 'src_tenant_name', 'src_segment_name',
+    list_columns = ['id', 'name', 'src_tenant_id', 'src_tenant_name',
+                    'src_segment_id', 'src_segment_name',
                     'src_ip', 'dst_ip', 'expected_result']
 
 
@@ -324,7 +338,8 @@ class ReachabilityQuickTestsCreate(extension.ClientExtensionCreate,
     """Create a Reachability Quick Test."""
 
     shell_command = 'reachability-quick-tests-create'
-    list_columns = ['id', 'name', 'src_tenant_name', 'src_segment_name',
+    list_columns = ['id', 'name', 'src_tenant_id', 'src_tenant_name',
+                    'src_segment_id', 'src_segment_name',
                     'src_ip', 'dst_ip', 'expected_result']
 
     def add_known_arguments(self, parser):
@@ -342,7 +357,8 @@ class ReachabilityQuickTestsUpdate(extension.ClientExtensionUpdate,
     """Update a Reachability Quick Test."""
 
     shell_command = 'reachability-quick-tests-update'
-    list_columns = ['id', 'name', 'src_tenant_name', 'src_segment_name',
+    list_columns = ['id', 'name', 'src_tenant_id', 'src_tenant_name',
+                    'src_segment_id', 'src_segment_name',
                     'src_ip', 'dst_ip', 'expected_result']
 
     def add_known_arguments(self, parser):
@@ -360,7 +376,8 @@ class ReachabilityQuickTestsRun(extension.ClientExtensionUpdate,
     """Run a Reachability Quick Test."""
 
     shell_command = 'reachability-quick-tests-run'
-    list_columns = ['id', 'name', 'src_tenant_name', 'src_segment_name',
+    list_columns = ['id', 'name', 'src_tenant_id', 'src_tenant_name',
+                    'src_segment_id', 'src_segment_name',
                     'src_ip', 'dst_ip', 'expected_result', 'test_result',
                     'detail', 'logical_path', 'test_time']
 

--- a/rhel/python-bsn-neutronclient.spec
+++ b/rhel/python-bsn-neutronclient.spec
@@ -3,7 +3,7 @@
 %global rpm_prefix openstackclient-bigswitch
 
 Name:           %{pypi_name}
-Version:        12.0.0
+Version:        12.0.1
 Release:        1%{?dist}
 Epoch:          1
 Summary:        Python bindings for Big Switch Networks Neutron API
@@ -45,6 +45,10 @@ export SKIP_PIP_INSTALL=1
 
 %postun
 
+
+
 %changelog
+* Mon Oct 08 2018 Weifan Fu <weifan.fu@bigswitch.com> - 12.0.1
+- OSP-246: Add src_tenant_id and src_segment_id for reachability tests
 * Mon Oct 08 2018 Aditya Vaja <wolverine.av@gmail.com> - 12.0.0
 - create queens branch for stable release

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = python-bsn-neutronclient
-version = 12.0.0
+version = 12.0.1
 summary = Python bindings for Big Switch Networks Neutron API
 description-file =
     README.rst


### PR DESCRIPTION
Reviewer: @wolverineav  @sarath-kumar 

As bsn neutron client is no longer part of networking-bigswitch (Even though it is not removed from it yet.). Changes need to be don the individual repo as welll.