### PR TITLE
use sudo when doing a git clean

### DIFF
--- a/build_scripts/openstack_python_bsn_neutronclient_pull_req.build
+++ b/build_scripts/openstack_python_bsn_neutronclient_pull_req.build
@@ -1,4 +1,4 @@
-git clean -fxd
+sudo git clean -fxd
 GIT_REPO=`pwd`
 
 DOCKER_IMAGE=$DOCKER_REGISTRY'/bosi-builder-py3:latest'


### PR DESCRIPTION
Reviewer: trivial

 - because container creates .tox directory as root user, outside
   the container, cleaning requires sudo