### PR TITLE
OSP-252: Update tox.ini on master, for python3

### DIFF
--- a/rhel/python-bsn-neutronclient.spec
+++ b/rhel/python-bsn-neutronclient.spec
@@ -1,0 +1,54 @@
+%global pypi_name python-bsn-neutronclient
+%global pypi_name_underscore python_bsn_neutronclient
+%global rpm_prefix openstackclient-bigswitch
+
+Name:           %{pypi_name}
+Version:        0.0.6
+Release:        1%{?dist}
+Epoch:          1
+Summary:        Python bindings for Big Switch Networks Neutron API
+License:        ASL 2.0
+URL:            https://pypi.python.org/pypi/%{pypi_name}
+Source0:        https://pypi.python.org/packages/source/b/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
+BuildArch:      noarch
+
+BuildRequires:  python-pbr
+BuildRequires:  python-setuptools
+
+Requires:       python-pbr >= 0.10.8
+Requires:       python-neutronclient >= 6.3.0
+
+%description
+This package contains Big Switch Networks
+python client for Openstack CLI.
+
+%prep
+%setup -q -n %{pypi_name}-%{version}
+
+%build
+export PBR_VERSION=%{version}
+export SKIP_PIP_INSTALL=1
+%{__python2} setup.py build
+
+%install
+%{__python2} setup.py install --skip-build --root %{buildroot}
+
+%files
+%license LICENSE
+%{python2_sitelib}/%{pypi_name_underscore}
+%{python2_sitelib}/*.egg-info
+
+
+%post
+
+%preun
+
+%postun
+
+%changelog
+* Tue Nov 20 2018 Weifan Fu <weifan.fu@bigswitch.com> - 0.0.6
+- OSP-252: update tox for py3
+* Mon Oct 08 2018 Aditya Vaja <wolverine.av@gmail.com> - 0.0.5
+- OSP-241: fix entry point extension name and import error
+* Tue Aug 21 2018 Aditya Vaja <wolverine.av@gmail.com> - 0.0.4
+- OSP-165: add force sync command for topo_sync and build changes

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = python-bsn-neutronclient
-version = 0.0.3
+version = 0.0.6
 summary = Python bindings for Big Switch Networks Neutron API
 description-file =
     README.rst

--- a/tox.ini
+++ b/tox.ini
@@ -16,12 +16,33 @@ deps = -r{toxinidir}/test-requirements.txt
 commands = stestr run {posargs}
 
 [testenv:pep8]
+basepython = python3
 commands = flake8 {posargs}
 
+[testenv:py27-dev]
+basepython = python2.7
+commands =
+    {[testenv:dev]commands}
+    {[testenv]commands}
+
+[testenv:py35-dev]
+basepython = python3.5
+commands =
+    {[testenv:dev]commands}
+    {[testenv]commands}
+
+[testenv:py36-dev]
+basepython = python3.6
+commands =
+    {[testenv:dev]commands}
+    {[testenv]commands}
+
 [testenv:venv]
+basepython = python3
 commands = {posargs}
 
 [testenv:cover]
+basepython = python3
 setenv =
     VIRTUAL_ENV={envdir}
     PYTHON=coverage run --source python_bsn_neutronclient --parallel-mode
@@ -32,9 +53,11 @@ commands =
     coverage xml -o cover/coverage.xml
 
 [testenv:docs]
-commands = python setup.py build_sphinx
+basepython = python3
+commands = python3 setup.py build_sphinx
 
 [testenv:releasenotes]
+basepython = python3
 commands =
   sphinx-build -a -E -W -d releasenotes/build/doctrees -b html releasenotes/source releasenotes/build/html
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,11 @@ commands = stestr run {posargs}
 basepython = python3
 commands = flake8 {posargs}
 
+[testenv:dev]
+basepython = python3
+# run locally (not in the gate) using editable mode
+# https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs
+
 [testenv:py27-dev]
 basepython = python2.7
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -19,27 +19,19 @@ commands = stestr run {posargs}
 basepython = python3
 commands = flake8 {posargs}
 
-[testenv:dev]
-basepython = python3
-# run locally (not in the gate) using editable mode
-# https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs
-
 [testenv:py27-dev]
 basepython = python2.7
 commands =
-    {[testenv:dev]commands}
     {[testenv]commands}
 
 [testenv:py35-dev]
 basepython = python3.5
 commands =
-    {[testenv:dev]commands}
     {[testenv]commands}
 
 [testenv:py36-dev]
 basepython = python3.6
 commands =
-    {[testenv:dev]commands}
     {[testenv]commands}
 
 [testenv:venv]


### PR DESCRIPTION
Reviewer: @sarath-kumar @WeifanFu-bsn 

 - same as PR #11
 - build for PR #11 was failing with error tox.ini not found 🤷🏻‍♂️
 - https://jenkins.bigswitch.com/view/OpenStack/job/openstack_python_bsn_neutronclient_pull_req/27/console

cloning as a new PR rebased on new master HEAD to see if it fixes it.